### PR TITLE
[FEAT #31] Response Format 통일

### DIFF
--- a/product-service/src/main/java/com/farmted/productservice/controller/ProductController.java
+++ b/product-service/src/main/java/com/farmted/productservice/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.farmted.productservice.dto.request.ProductModifyRequestDto;
 import com.farmted.productservice.dto.request.ProductSaveRequestDto;
 import com.farmted.productservice.dto.response.ProductResponseDto;
 import com.farmted.productservice.service.ProductService;
+import com.farmted.productservice.util.GlobalResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +25,7 @@ public class ProductController {
             @RequestHeader("UUID") String uuid // 멤버
     ) {
         productService.saveProduct(uuid,productSaveRequestDto);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(GlobalResponseDto.of(true));
     }
 
     // 판매자 등록 전체 상품 조회
@@ -34,7 +35,7 @@ public class ProductController {
             @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo
     ) {
         List<ProductResponseDto> listProductSeller = productService.getListProductSeller(memberUuid,pageNo);
-        return  ResponseEntity.ok(listProductSeller);
+        return  ResponseEntity.ok(GlobalResponseDto.of(listProductSeller));
     }
 
     // 판매자 가격 수정
@@ -46,7 +47,7 @@ public class ProductController {
     )
     {
         productService.modifyProduct(boardUuid, productModifyRequestDto,memberUuid);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(GlobalResponseDto.of(true));
     }
 
     // 판매자 전체 수정
@@ -58,13 +59,14 @@ public class ProductController {
             @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo
     ){
         List<ProductResponseDto> listProduct = productService.getListProduct(pageNo);
-        return ResponseEntity.ok(listProduct);
+        return ResponseEntity.ok(GlobalResponseDto.of(listProduct));
     }
 
     // 상품 상세 조회
     @GetMapping("/products/{board_uuid}/boards")
-    public ResponseEntity<ProductResponseDto> getProductDetail(@PathVariable (value = "board_uuid") String boardUuid){
-        return ResponseEntity.ok(productService.getProductDetail(boardUuid));
+    public ResponseEntity<?> getProductDetail(@PathVariable (value = "board_uuid") String boardUuid){
+        ProductResponseDto productDetail = productService.getProductDetail(boardUuid);
+        return ResponseEntity.ok(GlobalResponseDto.of(productDetail));
 
     }
 

--- a/product-service/src/main/java/com/farmted/productservice/controller/ProductController.java
+++ b/product-service/src/main/java/com/farmted/productservice/controller/ProductController.java
@@ -35,7 +35,7 @@ public class ProductController {
             @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo
     ) {
         List<ProductResponseDto> listProductSeller = productService.getListProductSeller(memberUuid,pageNo);
-        return  ResponseEntity.ok(GlobalResponseDto.of(listProductSeller));
+        return  ResponseEntity.ok(GlobalResponseDto.listOf(listProductSeller));
     }
 
     // 판매자 가격 수정
@@ -59,7 +59,7 @@ public class ProductController {
             @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo
     ){
         List<ProductResponseDto> listProduct = productService.getListProduct(pageNo);
-        return ResponseEntity.ok(GlobalResponseDto.of(listProduct));
+        return ResponseEntity.ok(GlobalResponseDto.listOf(listProduct));
     }
 
     // 상품 상세 조회

--- a/product-service/src/main/java/com/farmted/productservice/util/GlobalResponseDto.java
+++ b/product-service/src/main/java/com/farmted/productservice/util/GlobalResponseDto.java
@@ -1,0 +1,39 @@
+package com.farmted.productservice.util;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL) // 필드가 null 값일 경우 그 필드 제외하고 보냄.
+public class GlobalResponseDto<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess; //통신 결과를 보여주는 변수
+
+    private final T data ; // 실제 DTO를 담는 변수
+
+    @JsonCreator
+    private GlobalResponseDto(@JsonProperty("data") T data){
+        this.isSuccess = true;
+        this.data =data;
+    }
+
+
+    private GlobalResponseDto(Boolean isSuccess){
+        this.isSuccess = isSuccess;
+        this.data = null;
+    }
+
+
+    public static GlobalResponseDto<Void> of(boolean isSuccess){
+        return new GlobalResponseDto<>(isSuccess);
+    }
+
+    public static <T> GlobalResponseDto<T> of(T data){
+        return new GlobalResponseDto<>(data);
+    }
+
+
+}

--- a/product-service/src/main/java/com/farmted/productservice/util/GlobalResponseDto.java
+++ b/product-service/src/main/java/com/farmted/productservice/util/GlobalResponseDto.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL) // 필드가 null 값일 경우 그 필드 제외하고 보냄.
 public class GlobalResponseDto<T> {
@@ -34,6 +36,8 @@ public class GlobalResponseDto<T> {
     public static <T> GlobalResponseDto<T> of(T data){
         return new GlobalResponseDto<>(data);
     }
+
+    public static  <T> GlobalResponseDto<List<T>>  listOf(List<T> data){return new GlobalResponseDto<>(data);}
 
 
 }


### PR DESCRIPTION
필요성
비지니스 로직에서는 응답의 유형을 하나로 통일해서 받아야 하기 때문에 GlobalResponseDto 사용

내부 로직
isSuccess는 통신 연결에 대한 성공(true)과 실패값(false)입니다.
현재 DomainResponseDto형식으로 선언된 필드는 개별 마이크로 서비스마다 다르게 사용되기에, 응답의 유형을 통일하기 위해  제너릭 타입 <T>를 사용하고 있습니다. 

결과1
![image](https://github.com/farmtedPlaydata/farmted-Repo/assets/84445176/e27e0746-5d24-4220-9e35-b1609fa26b01)

결과2
![image](https://github.com/farmtedPlaydata/farmted-Repo/assets/84445176/c4973caf-be0c-461b-9da6-2eacda4f4b8a)
